### PR TITLE
Added an API GET method to retrieve all posts

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -25,16 +25,18 @@ class JSONServer(HandleRequests):
 
         if url["requested_resource"] == "posts":
             if url["pk"] == 0:
-                response_body = get_all_user_posts(url)
+                if "user_id" in url["query_params"]:
+                    logged_in_user_id = url["query_params"]["user_id"][0]
+                    response_body = get_all_user_posts(logged_in_user_id)
+                    return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+            else:
+                response_body = get_post(url["pk"])
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
-            response_body = get_post(url["pk"])
-            return self.response(response_body, status.HTTP_200_SUCCESS.value)
-        
         elif url["requested_resource"] == "categories":
             response_body = get_categories()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
-
 
         elif url["requested_resource"] == "users":
             if "email" in url["query_params"]:

--- a/json-server.py
+++ b/json-server.py
@@ -11,7 +11,7 @@ from views import (
 )
 from views import create_comment
 from views import create_tag, get_and_sort_tags
-from views import create_post
+from views import create_post, get_all_posts
 from views import post_category
 from views import create_posttag
 from views import get_categories
@@ -29,6 +29,8 @@ class JSONServer(HandleRequests):
                     logged_in_user_id = url["query_params"]["user_id"][0]
                     response_body = get_all_user_posts(logged_in_user_id)
                     return self.response(response_body, status.HTTP_200_SUCCESS.value)
+                response_body = get_all_posts()
+                return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
             else:
                 response_body = get_post(url["pk"])

--- a/json-server.py
+++ b/json-server.py
@@ -172,8 +172,9 @@ class JSONServer(HandleRequests):
 
             successfully_created = create_post(request_body)
             if successfully_created:
+                message = {"message": "Successfully created"}
                 return self.response(
-                    "Successfully created", status.HTTP_201_SUCCESS_CREATED.value
+                    json.dumps(message), status.HTTP_201_SUCCESS_CREATED.value
                 )
             return self.response(
                 "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -8,3 +8,4 @@ from .category import post_category
 from .post_tag import create_posttag
 from .category import get_categories
 from .tag import get_and_sort_tags
+from .post import get_all_posts

--- a/views/post.py
+++ b/views/post.py
@@ -56,6 +56,7 @@ def get_all_posts():
         LEFT JOIN Users AS u ON p.user_id = u.id
         LEFT JOIN Categories AS c ON p.category_id = c.id
         WHERE p.publication_date <= ?
+        AND p.approved = 1
         ORDER BY p.publication_date DESC
             """,
             (datetime.today(),),

--- a/views/post.py
+++ b/views/post.py
@@ -120,8 +120,8 @@ def get_post(pk):
                     p.publication_date AS publication_date,
                     p.image_url AS image_url,
                     p.user_id AS user_id,
-                username AS username
-                FROM sts p
+                    u.username AS username
+                FROM Posts p
                 LEFT JOIN Users u ON u.id = user_id
                 WHERE p.id = ?
                 """,

--- a/views/post.py
+++ b/views/post.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 
 
-def get_all_user_posts(pk):
+def get_all_user_posts(logged_in_user_id):
 
     with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
@@ -24,7 +24,7 @@ def get_all_user_posts(pk):
                 WHERE p.user_id = ?
                 ORDER BY p.publication_date DESC
             """,
-            (pk,),
+            (logged_in_user_id,),
         )
 
         query_results = db_cursor.fetchall()


### PR DESCRIPTION
Summary:
A new API GET method called get_all_posts() was added to post.py to retrieve all approved posts in the database and sort them in reverse chronological order. 
Also, the do_GET logic in json-server.py was modified to differentiate between the fetch calls for get_all_user_posts and get_all_posts.

This PR addresses the server-side functionality for NSS-Day-Cohort-68/rare-client-rare-team-1#36

**Test 1**
To test the general functionality:
* Send a GET request in postman to localhost:8000/posts
* You should receive an array of post objects, and user and category objects should be nested within each post, and they should be sorted with the most recent publication date first.

**Test 2**
To test whether non-approved posts are excluded from the results:
* Add a post to your db.sqlite3 with an approved value of 0.
* Repeat the GET request in postman.
* You should receive the same results as in Test 1 (i.e. the post that is not approved is excluded)

**Test 3**
To test whether posts with a publication date in the future are excluded:
* Add a post to your db.sqlite3 with a publication_date value in the future (e.g. "2025-01-01")
* Repeat the GET request in postman
* You should receive the same results as in Test 1 (i.e. the post with a future date is excluded)

**Test 4**
To test whether get_all_user_posts still triggers correctly after the changes I made in json-server:
* Send a GET request in postman to localhost:8000/posts/1
* You should receive a single post object with a post id of 1. 