### PR TITLE
Fixed HTTP message bug in API

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -20,6 +20,11 @@ from views import get_categories
 class JSONServer(HandleRequests):
 
     def do_GET(self):
+        http_404_message = {
+            "HTTP 404": "ERROR - The requested resource is not available"
+        }
+        http_500_message = {"HTTP 500": "ERROR - Unexpected error occurred"}
+
         response_body = ""
         url = self.parse_url(self.path)
 
@@ -30,34 +35,38 @@ class JSONServer(HandleRequests):
 
             response_body = get_post(url["pk"])
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
-        
-        elif url["requested_resource"] == "categories":
+
+        if url["requested_resource"] == "categories":
             response_body = get_categories()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
-
-        elif url["requested_resource"] == "tags":
+        if url["requested_resource"] == "tags":
             response_body = get_and_sort_tags()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
-        elif url["requested_resource"] == "users":
+        if url["requested_resource"] == "users":
             if "email" in url["query_params"]:
                 requested_email = url["query_params"]["email"][0]
                 user_token = login_user(requested_email)
                 if "valid" in user_token:
-                    self.response(user_token, status.HTTP_200_SUCCESS.value)
-                else:
-                    return self.response(
-                        "Unexpected error occurred",
-                        status.HTTP_500_SERVER_ERROR.value,
-                    )
+                    return self.response(user_token, status.HTTP_200_SUCCESS.value)
+                return self.response(
+                    json.dumps(http_500_message),
+                    status.HTTP_500_SERVER_ERROR.value,
+                )
 
         else:
             return self.response(
-                "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
+                json.dumps(http_404_message),
+                status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
             )
 
     def do_POST(self):
+        http_404_message = {
+            "HTTP 404": "ERROR - The requested resource is not available"
+        }
+        http_500_message = {"HTTP 500": "ERROR - Unexpected error occurred"}
+
         url = self.parse_url(self.path)
 
         try:
@@ -65,8 +74,9 @@ class JSONServer(HandleRequests):
             request_body = self.rfile.read(content_len)
             request_body = json.loads(request_body)
         except JSONDecodeError:
+            http_message = {"HTTP 400": "ERROR - No request body was provided"}
             return self.response(
-                "Error -- No information was provided.",
+                json.dumps(http_message),
                 status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
             )
 
@@ -76,8 +86,11 @@ class JSONServer(HandleRequests):
                 for key in expected_user_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete User information. Please provide values for first_name, last_name, username, and email."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for first_name, last_name, username, and email.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
@@ -85,7 +98,7 @@ class JSONServer(HandleRequests):
             if json.loads(token)["token"] > 0:
                 return self.response(token, status.HTTP_201_SUCCESS_CREATED.value)
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
             )
 
         if url["requested_resource"] == "comments":
@@ -94,18 +107,22 @@ class JSONServer(HandleRequests):
                 for key in expected_comment_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete Comment information. Please provide values for post_id, author_id, and content."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for post_id, author_id, content.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
             successfully_created = create_comment(request_body)
             if successfully_created:
+                http_message = {"HTTP 201": "SUCCESS - new Comment created"}
                 return self.response(
-                    "Successfully created", status.HTTP_201_SUCCESS_CREATED.value
+                    json.dumps(http_message), status.HTTP_201_SUCCESS_CREATED.value
                 )
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
             )
 
         if url["requested_resource"] == "categories":
@@ -114,19 +131,23 @@ class JSONServer(HandleRequests):
                 for key in expected_category_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete Category information. Please provide a value for label."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for category label.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
             successfully_created = post_category(request_body)
             if successfully_created:
+                http_message = {"HTTP 201": "SUCCESS - new Category created."}
                 return self.response(
-                    "Successfully created",
+                    json.dumps(http_message),
                     status.HTTP_201_SUCCESS_CREATED.value,
                 )
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
             )
 
         if url["requested_resource"] == "tags":
@@ -135,18 +156,22 @@ class JSONServer(HandleRequests):
                 for key in expected_tag_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete Tag information. Please provide a value for label."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for tag label.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
             successfully_created = create_tag(request_body)
             if successfully_created:
+                http_message = {"HTTP 201": "SUCCESS - new Tag created."}
                 return self.response(
-                    "Successfully created", status.HTTP_201_SUCCESS_CREATED.value
+                    json.dumps(http_message), status.HTTP_201_SUCCESS_CREATED.value
                 )
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
             )
 
         if url["requested_resource"] == "posts":
@@ -161,18 +186,22 @@ class JSONServer(HandleRequests):
                 for key in expected_post_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete Post information. Please provide values for user_id, category_id, title, image_url, and content."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for user_id, category_id, title, image_url, and content.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
             successfully_created = create_post(request_body)
             if successfully_created:
+                http_message = {"HTTP 201": "SUCCESS - new Post created."}
                 return self.response(
-                    "Successfully created", status.HTTP_201_SUCCESS_CREATED.value
+                    json.dumps(http_message), status.HTTP_201_SUCCESS_CREATED.value
                 )
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
             )
 
         if url["requested_resource"] == "posttags":
@@ -181,18 +210,28 @@ class JSONServer(HandleRequests):
                 for key in expected_posttag_keys:
                     value = request_body[key]
             except KeyError:
+                http_message = {
+                    "HTTP 400": "ERROR - Incomplete PostTag information. Please provide values for post_id and tag_id."
+                }
                 return self.response(
-                    "Incomplete user information. Please provide values for post_id and tag_id.",
+                    json.dumps(http_message),
                     status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
                 )
 
             successfully_created = create_posttag(request_body)
             if successfully_created:
+                http_message = {"HTTP 201": "SUCCESS - new PostTag created."}
                 return self.response(
-                    "Successfully created", status.HTTP_201_SUCCESS_CREATED.value
+                    json.dumps(http_message), status.HTTP_201_SUCCESS_CREATED.value
                 )
             return self.response(
-                "An unexpected error occurred.", status.HTTP_500_SERVER_ERROR.value
+                json.dumps(http_500_message), status.HTTP_500_SERVER_ERROR.value
+            )
+
+        else:
+            return self.response(
+                json.dumps(http_404_message),
+                status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
             )
 
     def do_PUT(self):


### PR DESCRIPTION
**Summary:**
Converted all HTTP response messages that were strings into objects so that they can be accessed more easily by the client side. 

This PR does not address a particular ticket. It is a server-wide update.

**Details:**
Converted message strings into json format. 
* e.g. `messageObject = {"HTTP 500": "Error - Unexpected error occurred"}`

Used json.dumps(messageObject) to serialize the message before sending with self.response()
* e.g. `return self.response(json.dumps(messageObject), status.HTTP_500.value)`

On the client side, the response object can be converted back to json using `await response.json()` and subsequently used in the code, if needed.

**To test:**
Send a request on postman that you know will trigger an error response. For example, send a post request to localhost:8000/tags and provide nothing in the body of the request. 
You should receive the associated response in the form of a json object rather than as a string. 

You can also verify that the error below is no longer being triggered by creating a new post. 
* Old error seen in the console upon clicking Publish on the New Post page: 
"Uncaught (in promise) SyntaxError: Unexpected token 's', "success" is not valid JSON"
* With the updates made in this PR, the above error has been cleared.